### PR TITLE
ツイート投稿保存機能の実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,4 +2,18 @@ class TweetsController < ApplicationController
   def index
     @tweets = Tweet.all
   end
+
+  def new 
+    @tweet = Tweet.new
+  end
+  
+  def create
+    Tweet.create(tweet_params)
+  end
+
+  private
+  def tweet_params
+    params.require(:tweet).permit(:name, :image, :text)
+  end
+  
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,2 +1,3 @@
 class Tweet < ApplicationRecord
+  validates :text, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,13 @@
 
   <body>
     <header class="header">
-      <div class= "header__bar row>
-        <h1 class="grid-6"><a href ="/">Pictweet</a></h1>
+      <div class="header__bar row">
+        <h1 class="grid-6"><a href="/">PicTweet</a></h1>
         <div class="user_nav grid-6">
           <a class="post" href="/tweets/new">投稿する</a>
         </div>
       </div>
-    </header> 
+    </header>
     <%= yield %>
     <footer>
       <p>

--- a/app/views/tweets/create.html.erb
+++ b/app/views/tweets/create.html.erb
@@ -1,0 +1,6 @@
+<div class="content row">
+  <div class ="success">
+    <h3>投稿が完了しました</h3>
+    <a class="btn" href="/">投稿一覧へ戻る</a>
+  </div>
+</div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,0 +1,11 @@
+<div class="contents row">
+  <div class="container">
+    <h3>投稿する</h3>
+    <%= form_with(model: @tweet, local: true) do |form| %>
+      <%= form.text_field :name, placeholder: "Nickname" %>
+      <%= form.text_field :image, placeholder: "Image Url" %>
+      <%= form.text_area :text, placeholder: "text", rows: "10" %>
+      <%= form.submit "SEND" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'tweets#index'
-  resources :tweets, only: :index
+  resources :tweets, only: [:index, :new ,:create]
 end


### PR DESCRIPTION
# What
ツイート投稿保存機能の実装

# Why
・テキスト、画像の投稿ができる。
・テキスト投稿者の名前もツイートに表示。
・バリデーションは、テキストが空だと投稿できないように指定。